### PR TITLE
Now detects explicit decimal (fixes #15)

### DIFF
--- a/copybook/parser.py
+++ b/copybook/parser.py
@@ -34,8 +34,8 @@ numeric_pic = Group(
     )
     + Optional(
         (
-            ("V"+FollowedBy("9")("implied_decimal"))
-            | ("."+FollowedBy("9")("explicit_decimal"))
+            ("V"+FollowedBy("9"))("implied_decimal")
+            | ("."+FollowedBy("9"))("explicit_decimal")
         )
         # bracket notation, e.g. 9(13)
         + (

--- a/tests/test_parse_string.py
+++ b/tests/test_parse_string.py
@@ -155,7 +155,7 @@ def test_plus_sign_control_symbol():
     result = copybook.parse_string(test_str).flatten()
     assert len(result)==2
     assert result[1].datatype=="decimal"
-    assert result[1].get_total_length()==7
+    assert result[1].get_total_length()==8
 
 def test_minus_sign_control_symbol():
     test_str = """
@@ -165,4 +165,15 @@ def test_minus_sign_control_symbol():
     result = copybook.parse_string(test_str).flatten()
     assert len(result)==2
     assert result[1].datatype=="decimal"
+    assert result[1].get_total_length()==8
+
+def test_explicit_decimal():
+    test_str = """
+       01  WORK-BOOK.
+         10  AMOUNT2       PIC 9(4).99.
+    """
+    result = copybook.parse_string(test_str).flatten()
+    assert len(result)==2
+    assert result[1].datatype=="decimal"
+    assert result[1].explicit_decimal == True
     assert result[1].get_total_length()==7


### PR DESCRIPTION
I missed this when I submitted PR #14, so my test cases for that PR didn't account for the explicit decimal when checking total length. I updated those test cases in this new PR.

Thanks for this very useful package.